### PR TITLE
Upgrade Asterisk Docker to v20

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Asterisk 20 Docker Setup
+
+This project builds a simple Asterisk 20 container and a small Python bridge.
+
+## Build
+
+```
+./setup.sh
+```
+
+`setup.sh` builds both Docker images using the provided Dockerfiles.
+
+## Run
+
+```
+docker compose up
+```
+
+Asterisk will start in the `asterisk` container. Ensure there is no
+"Stasis initialization failed" message in the logs. The bridge container
+starts after Asterisk and waits for audio on `/tmp/audio.pipe`.
+

--- a/asterisk/Dockerfile
+++ b/asterisk/Dockerfile
@@ -4,10 +4,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Обновление и установка зависимостей
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    asterisk \
-    asterisk-dahdi \
-    asterisk-core-sounds-en \
-    asterisk-moh-opsound-wav \
+    gnupg wget \
+ && wget -O - https://downloads.asterisk.org/pub/keys/asterisk-signing-key.asc | gpg --dearmor >/usr/share/keyrings/asterisk-archive-keyring.gpg \
+ && echo "deb [signed-by=/usr/share/keyrings/asterisk-archive-keyring.gpg] https://packages.asterisk.org/deb $(lsb_release -cs) main" > /etc/apt/sources.list.d/asterisk.list \
+ && apt-get update && apt-get install -y --no-install-recommends \
+    asterisk=20.* \
+    asterisk-dahdi=20.* \
+    asterisk-core-sounds-en=20.* \
+    asterisk-moh-opsound-wav=20.* \
     openssl \
     curl \
     vim \


### PR DESCRIPTION
## Summary
- install Asterisk 20 from Sangoma apt repo
- document the new build and run steps

## Testing
- `bash setup.sh` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d835ea0dc832d85ffdf8775ab9e9c